### PR TITLE
Fix resource linking errors in layout files

### DIFF
--- a/app/src/main/res/layout/item_place_horizontal.xml
+++ b/app/src/main/res/layout/item_place_horizontal.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.google.android.material.card.MaterialCardView
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res/auto"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="200dp"
     android:layout_height="wrap_content"


### PR DESCRIPTION
Corrected XML namespace declaration to resolve Android resource linking errors.

The previous declaration `xmlns:app="http://schemas.android.com/apk/res/auto"` was missing a hyphen, causing `MaterialCardView` attributes like `cardCornerRadius` and `cardElevation` to not be found during compilation.

---
<a href="https://cursor.com/background-agent?bcId=bc-154b0899-3a2a-482b-8bc6-2beec4cbdef0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-154b0899-3a2a-482b-8bc6-2beec4cbdef0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

