### PR TITLE
Fix activity action bar conflict

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -80,7 +80,7 @@
         <activity
             android:name=".ui.main.MainActivity"
             android:exported="true"
-            android:theme="@style/Theme.WorldCup2026SmartGuide">
+            android:theme="@style/Theme.WorldCup2026SmartGuide.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -68,4 +68,10 @@
         <item name="textAppearanceBody2">@style/TextAppearance.WorldCup.Body2</item>
         <item name="textAppearanceCaption">@style/TextAppearance.WorldCup.Caption</item>
     </style>
+
+    <!-- No Action Bar Theme -->
+    <style name="Theme.WorldCup2026SmartGuide.NoActionBar">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
 </resources>


### PR DESCRIPTION
Fix `IllegalStateException` by changing MainActivity's theme to `NoActionBar` to resolve action bar conflicts with a custom toolbar and ensure night theme consistency.

The `IllegalStateException` occurred because `MainActivity` was attempting to set a custom `MaterialToolbar` as the support action bar using `setSupportActionBar()`, while its assigned theme implicitly provided a default action bar. This dual action bar setup caused the crash. The fix involves explicitly setting `MainActivity` to use a `NoActionBar` theme, which disables the default window action bar, allowing the custom toolbar to be used without conflict. The corresponding `NoActionBar` style was also added to the night theme for complete coverage.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ad6258e-896c-40bd-b3d8-37caa6b77a8b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7ad6258e-896c-40bd-b3d8-37caa6b77a8b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

